### PR TITLE
Syncronize deps with hub-extensions/check-tools

### DIFF
--- a/Formula/hub.rb
+++ b/Formula/hub.rb
@@ -7,10 +7,12 @@ class Hub < Formula
     license "MIT"
     head "https://github.com/agilestacks/hub"
 
-
-    depends_on "jq"        
-    depends_on "npm"        
-
+    depends_on "git" => :recommended
+    depends_on "awscli"        
+    depends_on "kubectl"        
+    depends_on "npm" => :optional
+    depends_on "jq"  => "9.3"  
+    depends_on "yq"  => "3.2"      
 
     def install
         chmod "+x", "hub.darwin_amd64"

--- a/Formula/hubcli.rb
+++ b/Formula/hubcli.rb
@@ -1,4 +1,4 @@
-class HubCli < Formula
+class Hubcli < Formula
     desc "CLI to manage your deployments"
     homepage "https://www.superhub.io/"
     url "https://controlplane.agilestacks.io/dist/hub-cli/hub.darwin_amd64"

--- a/Formula/hubcli.rb
+++ b/Formula/hubcli.rb
@@ -1,12 +1,13 @@
-class Hub < Formula
-    desc "Agile Stacks cli tool to manage stacks"
-    homepage "https://www.agilestacks.com/"
+class HubCli < Formula
+    desc "CLI to manage your deployments"
+    homepage "https://www.superhub.io/"
     url "https://controlplane.agilestacks.io/dist/hub-cli/hub.darwin_amd64"
-    version "0.20.9"
+    version "0.20.10"
     sha256 "34856f5ed4c62e20d6b18c1c316143a94f03f68b51a0b768de7a4132cd5ae9c2"
     license "MIT"
     head "https://github.com/agilestacks/hub"
 
+    conflicts_with "hub", because: "binary naming conflict"
     depends_on "git" => :recommended
     depends_on "awscli"        
     depends_on "kubectl"        
@@ -22,7 +23,7 @@ class Hub < Formula
     def post_install
         hub_home = Pathname.new "#{Dir.home}/.hub"
         unless hub_home.exist?
-            system "#{Formula["hub"].opt_bin}/hub", "extensions", "install"
+            system "#{Formula["hubcli"].opt_bin}/hub", "extensions", "install"
         end 
     end
 


### PR DESCRIPTION
- [ ] Latest dependency list from hub-extensions/check-tools
- [ ] Steering to `hubcli` to avoid naming conflict with [`hub`](https://github.com/github/hub) (from Github) as `brew install hub` tends to install this one tool